### PR TITLE
Graph Types: add knowledge graph implementation

### DIFF
--- a/graph/dot/dot.go
+++ b/graph/dot/dot.go
@@ -29,15 +29,29 @@ func (g *DotGraph[T, I]) Add(from, to T, weight I) {
 	if weight == 0 {
 		return
 	}
+
+	// fmt operations for ease of use
+	fromStr := fmt.Sprint(from)
+	toStr := fmt.Sprint(to)
+	var weightStr string
+
+	if str, ok := (interface{})(weight).(interface {
+		String() string
+	}); ok {
+		weightStr = str.String()
+	} else {
+		weightStr = fmt.Sprint(weight)
+	}
+
 	g.buf.WriteString(`    `)
-	g.buf.WriteString(fmt.Sprint(from))
+	g.buf.WriteString(fromStr)
 	g.buf.WriteString(` -> `)
-	g.buf.WriteString(fmt.Sprint(to))
+	g.buf.WriteString(toStr)
 	if (weight != 0 && weight != 1) || g.cfg.WeightKey == string(LabelWeight) {
 		g.buf.WriteString(` [`)
 		g.buf.WriteString(g.cfg.WeightKey)
 		g.buf.WriteString(`=`)
-		g.buf.WriteString(fmt.Sprint(weight))
+		g.buf.WriteString(weightStr)
 		g.buf.WriteString(`]`)
 	}
 	g.buf.WriteString(`

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -6,6 +6,7 @@ package graph
 import (
 	"reflect"
 
+	"github.com/zalgonoise/x/graph/knowledge"
 	"github.com/zalgonoise/x/graph/list"
 	"github.com/zalgonoise/x/graph/matrix"
 	"github.com/zalgonoise/x/graph/model"
@@ -23,6 +24,8 @@ func New[T model.ID, I model.Num](id T, value any, opts ...options.Setting) mode
 		return list.New[T, I](id, value, config)
 	case options.GraphMatrix:
 		return matrix.New[T, I](id, value, config)
+	case options.GraphKnowledge:
+		return knowledge.New[T, I](id, value, config)
 	default:
 		return matrix.New[T, I](id, value, config)
 	}

--- a/graph/knowledge/actions.go
+++ b/graph/knowledge/actions.go
@@ -1,0 +1,311 @@
+package knowledge
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/zalgonoise/x/graph/actions"
+	"github.com/zalgonoise/x/graph/dot"
+	"github.com/zalgonoise/x/graph/errs"
+	"github.com/zalgonoise/x/graph/model"
+	"github.com/zalgonoise/x/graph/options"
+)
+
+func getKeysFromList[T model.ID, I model.Num](g Graph[T, I]) map[T]model.Graph[T, I] {
+	m := *g.adjacency()
+	keyMap := map[T]model.Graph[T, I]{}
+
+	for k := range m {
+		keyMap[k.ID()] = k
+	}
+	return keyMap
+}
+
+func AddNodesToList[T model.ID, I model.Num](g Graph[T, I], conf options.Setting, nodes ...model.Graph[T, I]) error {
+	config := options.New(conf)
+
+	if config.MaxDepth > 0 && actions.GraphDepth[T, I](g) >= config.MaxDepth {
+		return errs.MaxDepthReached
+	}
+
+	m := g.adjacency()
+	n := *m
+
+	count := len(n)
+
+	for idx, node := range nodes {
+		if config.MaxNodes > 0 && count+idx >= config.MaxNodes {
+			return errs.MaxNodesReached
+		}
+
+		if _, ok := n[node]; ok {
+			return errs.AlreadyExists
+		}
+
+		// link node to parent before adding it to graph
+		err := node.Link(g, conf)
+		if err != nil {
+			return err
+		}
+
+		n[node] = map[I][]model.Graph[T, I]{}
+
+	}
+
+	*m = n
+	return nil
+}
+
+func RemoveNodesFromList[T model.ID, I model.Num](g Graph[T, I], ids ...T) error {
+	m := g.adjacency()
+	n := *m
+
+	for _, id := range ids {
+		node, err := g.Get(id)
+		if err != nil {
+			return err
+		}
+
+		// disconnect any edges
+		for innerNode, innerEdges := range n {
+			if innerNode == node {
+				continue
+			}
+			for _, iEdges := range innerEdges {
+				for _, e := range iEdges {
+					if e.ID() == node.ID() {
+						err := g.Disconnect(innerNode.ID(), node.ID())
+						if err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+
+		// remove node
+		delete(n, node)
+
+		// unlink node from graph
+		err = node.Link(nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	*m = n
+	return nil
+}
+
+func GetNodeFromList[T model.ID, I model.Num](g Graph[T, I], node T) (model.Graph[T, I], error) {
+	k := getKeysFromList(g)
+
+	n, ok := k[node]
+	if !ok {
+		return nil, errs.DoesNotExist
+	}
+
+	return n, nil
+}
+
+func ListNodesFromList[T model.ID, I model.Num](g Graph[T, I]) ([]model.Graph[T, I], error) {
+	m := *g.adjacency()
+
+	out := []model.Graph[T, I]{}
+
+	for k := range m {
+		out = append(out, k)
+	}
+
+	return out, nil
+}
+
+func AddEdgeInList[T model.ID, I model.Num](g Graph[T, I], from, to T, weight I, isNonDir, isNonCyc bool) error {
+	var (
+		graph  model.Graph[T, I] = g
+		toNode model.Graph[T, I]
+	)
+
+	if g == nil {
+		return fmt.Errorf("unable to read graph (nil): %w", errs.DoesNotExist)
+	}
+	k := getKeysFromList(g)
+
+	fromNode, ok := k[from]
+	if !ok {
+		return fmt.Errorf("from node: %w", errs.DoesNotExist)
+	}
+
+	toNode, ok = k[to]
+	if !ok {
+		parent, err := actions.LeafLookup(graph, to)
+		if err != nil && errors.Is(err, errs.DoesNotExist) {
+			return fmt.Errorf("to node: %w", err)
+		}
+		toNode, err = parent.Get(to)
+		if err != nil {
+			return err
+		}
+	}
+
+	if isNonCyc {
+		ok, err := actions.DepthFirstSearch[T, I](g, actions.VerifyCycles(fromNode, toNode), toNode)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return errs.CyclicalEdge
+		}
+	}
+
+	if weight == 0 {
+		if isNonDir {
+			return RemoveEdgeFromList(fromNode, toNode)
+		} else {
+			err := RemoveEdgeFromList(fromNode, toNode)
+			if err != nil {
+				return fmt.Errorf("Error removing edge %v from node %v: %v", toNode.ID(), fromNode.ID(), err)
+			}
+			return RemoveEdgeFromList(toNode, fromNode)
+		}
+	}
+	if isNonDir {
+		err := AddEdgeInListUni(fromNode, toNode, weight)
+		if err != nil {
+			return fmt.Errorf("Error adding edge %v from node %v with weight %v: %v", toNode.ID(), fromNode.ID(), weight, err)
+		}
+		return AddEdgeInListUni(toNode, fromNode, weight)
+	}
+	return AddEdgeInListUni(fromNode, toNode, weight)
+
+}
+
+func RemoveEdgeFromList[T model.ID, I model.Num](from, to model.Graph[T, I]) error {
+	g, ok := from.Parent().(Graph[T, I])
+	if !ok {
+		err := g.Disconnect(from.ID(), to.ID())
+		if err != nil {
+			return fmt.Errorf("node %v's parent graph %v does not support cross-graph connections: %w", to.ID(), g.ID(), err)
+		}
+		return nil
+	}
+
+	m := *g.adjacency()
+	im := m[from]
+	for prop, edges := range im {
+		for idx, e := range edges {
+			if e.ID() == to.ID() {
+				edges[idx] = edges[len(edges)-1]
+				im[prop] = edges[:len(edges)-1]
+			}
+		}
+	}
+	return nil
+}
+
+func AddEdgeInListUni[T model.ID, I model.Num](from, to model.Graph[T, I], weight I) error {
+	g, ok := from.Parent().(Graph[T, I])
+	if !ok {
+		err := g.Connect(from.ID(), to.ID(), weight)
+		if err != nil {
+			return fmt.Errorf("node %v's parent graph %v does not support cross-graph connections: %w", to.ID(), g.ID(), err)
+		}
+		return nil
+	}
+
+	m := *g.adjacency()
+	m[from][weight] = append(m[from][weight], to)
+	return nil
+}
+
+func GetEdgesFromListNode[T model.ID, I model.Num](g Graph[T, I], node T) ([]model.Graph[T, I], error) {
+	m := *g.adjacency()
+	k := getKeysFromList(g)
+
+	target, ok := k[node]
+	if !ok {
+		return nil, errs.DoesNotExist
+	}
+
+	var allEdges []model.Graph[T, I]
+
+	for _, edges := range m[target] {
+		for _, e := range edges {
+			allEdges = append(allEdges, e)
+		}
+	}
+
+	return allEdges, nil
+}
+
+func GetWeightFromEdgesInList[T model.ID, I model.Num](g Graph[T, I], from, to T) (I, error) {
+	fromNode, err := g.Get(from)
+	if err != nil {
+		return 0, err
+	}
+	m := *g.adjacency()
+
+	for prop, edges := range m[fromNode] {
+		for _, e := range edges {
+			if e.ID() == to {
+				return prop, nil
+			}
+		}
+	}
+
+	return 0, nil
+}
+
+func GetEdgesWithProperty[T model.ID, I model.Num](g Graph[T, I], from T, weight I) ([]model.Graph[T, I], error) {
+	fromNode, err := g.Get(from)
+	if err != nil {
+		return nil, err
+	}
+	m := *g.adjacency()
+
+	var out []model.Graph[T, I]
+
+	list, ok := m[fromNode][weight]
+	if !ok {
+		return out, nil
+	}
+	return list, nil
+}
+
+func GetNodeProperties[T model.ID, I model.Num](g Graph[T, I], from T) ([]I, error) {
+	fromNode, err := g.Get(from)
+	if err != nil {
+		return nil, err
+	}
+	m := *g.adjacency()
+
+	var out []I
+
+	emap := m[fromNode]
+	for k := range emap {
+		out = append(out, k)
+	}
+
+	return out, nil
+}
+
+func (g *knowledgeGraph[T, I]) String() string {
+	var dirSetting dot.Direction
+
+	if g.conf.IsNonDirectional {
+		dirSetting = dot.Undirected
+	} else {
+		dirSetting = dot.Directed
+	}
+
+	dotGraph := dot.New[T, I](dirSetting)
+
+	for k, v := range g.n {
+		for prop, ies := range v {
+			for _, e := range ies {
+				dotGraph.Add(k.ID(), e.ID(), prop)
+			}
+		}
+	}
+	return dotGraph.String()
+}

--- a/graph/knowledge/knowledge.go
+++ b/graph/knowledge/knowledge.go
@@ -1,0 +1,130 @@
+package knowledge
+
+import (
+	"fmt"
+
+	"github.com/zalgonoise/x/graph/errs"
+	"github.com/zalgonoise/x/graph/model"
+	"github.com/zalgonoise/x/graph/options"
+)
+
+type Graph[T model.ID, I model.Num] interface {
+	model.Graph[T, I]
+	adjacency() *map[model.Graph[T, I]]map[I][]model.Graph[T, I]
+	EdgesWithProperty(node T, weight I) ([]model.Graph[T, I], error)
+	Properties(node T) ([]I, error)
+}
+
+type knowledgeGraph[T model.ID, I model.Num] struct {
+	locked bool
+	id     T
+	v      any
+	n      map[model.Graph[T, I]]map[I][]model.Graph[T, I]
+	parent model.Graph[T, I]
+
+	conf *options.GraphConfig
+}
+
+func New[T model.ID, I model.Num](id T, v any, conf options.Setting) model.Graph[T, I] {
+	c := options.New(conf)
+	if c.GraphType != options.GraphKnowledge {
+		c.GraphType = options.GraphKnowledge
+	}
+
+	return &knowledgeGraph[T, I]{
+		id:     id,
+		v:      v,
+		n:      map[model.Graph[T, I]]map[I][]model.Graph[T, I]{},
+		parent: nil,
+
+		conf: c,
+	}
+}
+
+func (g *knowledgeGraph[T, I]) adjacency() *map[model.Graph[T, I]]map[I][]model.Graph[T, I] {
+	return &g.n
+}
+func (g *knowledgeGraph[T, I]) ID() T {
+	return g.id
+}
+func (g *knowledgeGraph[T, I]) Value() any {
+	return g.v
+}
+func (g *knowledgeGraph[T, I]) Parent() model.Graph[T, I] {
+	return g.parent
+}
+func (g *knowledgeGraph[T, I]) Link(parent model.Graph[T, I], conf ...options.Setting) error {
+	if parent == nil {
+		g.parent = nil
+		return nil
+	}
+
+	if parent.ID() == g.ID() {
+		return fmt.Errorf("cannot set graph's parent to self: %w", errs.InvalidOperation)
+	}
+	g.parent = parent
+	if g.conf.ReadOnly {
+		g.locked = true
+	}
+
+	n := len(conf)
+	if n == 1 {
+		conf[0].Apply(g.conf)
+	} else if n > 1 {
+		options.MultiOption(conf...).Apply(g.conf)
+	}
+
+	return nil
+}
+func (g *knowledgeGraph[T, I]) Config() options.Setting {
+	conf := options.New(g.conf)
+	return conf
+}
+func (g *knowledgeGraph[T, I]) Add(nodes ...model.Graph[T, I]) error {
+	if g.locked {
+		return errs.ReadOnly
+	}
+	return AddNodesToList[T, I](g, g.conf, nodes...)
+}
+func (g *knowledgeGraph[T, I]) Remove(nodes ...T) error {
+	if g.locked {
+		return errs.ReadOnly
+	}
+	if g.conf.Immutable {
+		return errs.Immutable
+	}
+	return RemoveNodesFromList[T, I](g, nodes...)
+}
+func (g *knowledgeGraph[T, I]) Get(node T) (model.Graph[T, I], error) {
+	return GetNodeFromList[T, I](g, node)
+}
+func (g *knowledgeGraph[T, I]) List() ([]model.Graph[T, I], error) {
+	return ListNodesFromList[T, I](g)
+}
+func (g *knowledgeGraph[T, I]) Connect(from, to T, weight I) error {
+	if g.locked {
+		return errs.ReadOnly
+	}
+	return AddEdgeInList[T, I](g, from, to, weight, g.conf.IsNonDirectional, g.conf.IsNonCyclical)
+}
+func (g *knowledgeGraph[T, I]) Disconnect(from, to T) error {
+	if g.locked {
+		return errs.ReadOnly
+	}
+	if g.conf.Immutable {
+		return errs.Immutable
+	}
+	return AddEdgeInList[T, I](g, from, to, 0, g.conf.IsNonDirectional, g.conf.IsNonCyclical)
+}
+func (g *knowledgeGraph[T, I]) Edges(node T) ([]model.Graph[T, I], error) {
+	return GetEdgesFromListNode[T, I](g, node)
+}
+func (g *knowledgeGraph[T, I]) EdgesWithProperty(node T, weight I) ([]model.Graph[T, I], error) {
+	return GetEdgesWithProperty[T, I](g, node, weight)
+}
+func (g *knowledgeGraph[T, I]) Properties(node T) ([]I, error) {
+	return GetNodeProperties[T, I](g, node)
+}
+func (g *knowledgeGraph[T, I]) Weight(from, to T) (I, error) {
+	return GetWeightFromEdgesInList[T, I](g, from, to)
+}

--- a/graph/options/options.go
+++ b/graph/options/options.go
@@ -16,6 +16,7 @@ type (
 const (
 	GraphList TypeSetting = iota
 	GraphMatrix
+	GraphKnowledge
 )
 const (
 	Directional DirectionSetting = iota


### PR DESCRIPTION
Placeholder PR for a knowledge graph.

Kind of a hybrid between adjacency list graphs and adjacency matrix graphs, knowledge graphs have a hybrid of these, building a map of graphs to another map, of weights to a list of graphs.

There is a fast access to a node's properties (edges with different weights) when using maps, and there is a slice holding the edges with such property, avoiding to overload the memory with redundant mapping of a node matrix. As an overview, it has the performance advantages of each implementation by taking their best qualities.

Regarding weights, these should be regarded as properties, not actual numerical values (distance, cost, weight). Properties in go can be enumerated with a custom type based off an integer type (regardless), so you can customize properties independently.

For comparison, note the difference in the graph's structures:

Graph Type | Data structure | Details
:--:|:--:|:--:
Adjacency List | `map[model.Graph[T, I]][]model.Graph[T, I]` | weights are stored in a wrapper struct holding the graph and the weight, if anything but `1`
Adjacency Matrix | `map[model.Graph[T, I]]map[model.Graph[T, I]]I` | weights are stored as the items in the matrix cross eachother
Knowledge Graph | `map[model.Graph[T, I]]map[I][]model.Graph[T, I]` | weights are first-class citizens in edge connections

### Idea

- for one to be able to define X properties as custom type constants (based on an integer type)
- use that custom type to initialize the graph, as its weight type
- define node edges based on a specific property, using the weight 

### Example


```go
// pseudo-code

package kgraph

import (
	"github.com/zalgonoise/x/graph"
	"github.com/zalgonoise/x/graph/options"
)

type Property uint

const (
	Undefined Property = iota // keep index 0 clear
	InstanceOf 
	Occupation
	// more properties
)

func main() {
	root := graph.New[string, Property]("root", options.NoType, options.GraphKnowledge)

	nodes := graph.Gen[string, Property](
		options.GraphKnowledge,
		"John Doe",
		"Human",
		"Software Developer",
	)

	err := root.Add(nodes...)
	// handle err

	err = root.Connect("John Doe", "Human", InstanceOf)
	// handle err

	err = root.Connect("John Doe", "Software Developer", Occupation)
	// handle err
}
```